### PR TITLE
chore: add mobile-forever to replace px-to-viewport to improve a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - 🎨 使用 postcss / sass 编写 CSS
 - 📒 封装 [axios](https://axios-http.com) - 更好的管理 API，代码即 API 文档
 - 📬 API Mock Data - 通过 mock-dev-server 在项目开发环境中对 接口进行 mock
-- ⚖️ px to viewport
+- ⚖️ 使用 [mobile-forever](https://github.com/wswmsword/postcss-mobile-forever) 实现移动端伸缩视图，兼容适配桌面端（可关闭）
 - 📐 eslint
 - ⏳ git hooks - 规范 git commit 内容格式
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint-staged": "^15.2.10",
     "pnpm": "^9.11.0",
     "postcss": "^8.4.47",
-    "postcss-px-to-viewport-8-plugin": "^1.2.5",
+    "postcss-mobile-forever": "^4.1.6",
     "sass-embedded": "^1.79.3",
     "sort-package-json": "^2.10.1",
     "terser": "^5.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
-      postcss-px-to-viewport-8-plugin:
-        specifier: ^1.2.5
-        version: 1.2.5
+      postcss-mobile-forever:
+        specifier: ^4.1.6
+        version: 4.1.6(postcss@8.4.47)
       sass-embedded:
         specifier: ^1.79.3
         version: 1.79.3
@@ -1231,46 +1231,55 @@ packages:
     resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.22.4':
     resolution: {integrity: sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.22.4':
     resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.22.4':
     resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
     resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.22.4':
     resolution: {integrity: sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.22.4':
     resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.22.4':
     resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.22.4':
     resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.22.4':
     resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
@@ -3710,8 +3719,10 @@ packages:
     engines: {node: '>=18.12'}
     hasBin: true
 
-  postcss-px-to-viewport-8-plugin@1.2.5:
-    resolution: {integrity: sha512-+yc69+q/euV7iKh5fGXY6C/lpepmVx2DGFHeYj5BpzIFyBBpdACDjZyrZ8AV0kCg+J0bplBv4ZA1QTzgaK0rGg==}
+  postcss-mobile-forever@4.1.6:
+    resolution: {integrity: sha512-ITf1YWFLMDGG6GXPY9bTUS9643SLEgrTitrjHrMTkFmCoDTJsBzKzphYFFxmDTXzN2ceVfxVB541KFx4IwBSKA==}
+    peerDependencies:
+      postcss: ^8.0.0
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -8858,9 +8869,9 @@ snapshots:
 
   pnpm@9.11.0: {}
 
-  postcss-px-to-viewport-8-plugin@1.2.5:
+  postcss-mobile-forever@4.1.6(postcss@8.4.47):
     dependencies:
-      object-assign: 4.1.1
+      postcss: 8.4.47
 
   postcss-selector-parser@6.1.2:
     dependencies:

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,9 +1,11 @@
 module.exports = {
   plugins: {
     'autoprefixer': {},
-    // https://github.com/lkxian888/postcss-px-to-viewport-8-plugin
-    'postcss-px-to-viewport-8-plugin': {
+    // https://github.com/wswmsword/postcss-mobile-forever
+    'postcss-mobile-forever': {
       viewportWidth: 375,
+      maxDisplayWidth: 600,
+      border: true,
     },
   },
 }


### PR DESCRIPTION
嗨鹏展博，我看到你的移动端模版觉得不错，用了 vw 的适配方法，正好我之前写了个插件，可以解决 vw 适配在大屏（桌面端、移动端横屏）难以阅览的问题，就在你的项目用这个插件做了适配，您看下效果，如果觉得不错希望可以合并～

<table>
	<tr>
		<td><img src="https://github.com/user-attachments/assets/9901f172-aea8-4bdd-9432-1cd9cd37f21e" alt="桌面端的展示效果" /></td>
		<td><img src="https://github.com/user-attachments/assets/ab7413f4-54e7-4efd-9880-5129b5ae9cd3" alt="移动端的展示效果" /></td>
	</tr>
</table>

这个插件是 [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)。使用方法很简单，对于限制最大宽度的属性也是可选的，如果用户不希望适配大屏，把 `maxDisplayWidth` 属性移去即可：

```diff
module.exports = {
  plugins: {
    'autoprefixer': {},
    // https://github.com/wswmsword/postcss-mobile-forever
    'postcss-mobile-forever': {
      viewportWidth: 375,
-     maxDisplayWidth: 600,
-     border: true,
    },
  },
}
```